### PR TITLE
Add new action for recalling macros

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -18,6 +18,7 @@ This module has been tested on the following switcher models. If you would like 
   - Change AUX sources
   - Cut & Auto transitions (ME and MELite)
   - Cut & Auto transitions (KEY, DSK, and FlexKey)
+  - Recall/playback macros by id #
   - Reboot the switcher
   - Send the switcher a custom command (**Note**: If you send something the switcher doesnt understand, it may drop the connection.)
   - Variables for _Key On Air_ and _Last Recalled Event_
@@ -29,7 +30,6 @@ This module has been tested on the following switcher models. If you would like 
 ## Planned / Coming Soon
 
 - Pull source names from the switcher
-- Recall/playback macros by id #
 - Better disconnect detection
 - **Feedbacks**
   - Tally (PVW / PGM / Clear)

--- a/actions.js
+++ b/actions.js
@@ -42,6 +42,20 @@ module.exports = {
 				},
 			],
 		}
+		actions['recall_macro'] = {
+			label: 'Recall Macro',
+			options: [
+				{
+					type: 'number',
+					label: 'Macro Number',
+					id: 'macro',
+					default: 0,
+					min: 0,
+					max: 99,
+					required: true,
+				},
+			],
+		}
 		actions['reconnect'] = {
 			label: 'Reconnect',
 			tooltip: 'If the switcher drops the connection, this action will reconnect.',
@@ -310,6 +324,13 @@ module.exports = {
 				let eventInt = parseInt(options.event) + 1 // Although the switcher labels them starting at 0, they are recalled with a 1 base...
 				let eventHex = ('0' + eventInt.toString(16)).slice(-2) // The switcher expects the event Id as a 2-digit hexidecimal
 				command = (protocol[model].COMMANDS.RECALL_EVENT || '').replace('{event}', eventHex)
+				break
+			case 'recall_macro':
+				let macroInt = parseInt(options.macro)
+				let macroHex = ('0' + macroInt.toString(16)).slice(-2) // Some switchers expects the macro Id as a 2-digit hexidecimal
+				command = (protocol[model].COMMANDS.RECALL_MACRO || '')
+					.replace('{macroInt}', macroInt)
+					.replace('{macroHex}', macroHex)
 				break
 			case 'trans_me':
 				command = (protocol[model].COMMANDS[`TRANS_ME_${options.type}`] || '').replace('{me}', options.me)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fora-hvs",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"description": "For.A Hanabi Video Switcher module for Companion.",
 	"main": "index.js",
 	"scripts": {

--- a/protocol_hvs100.js
+++ b/protocol_hvs100.js
@@ -6,6 +6,8 @@ module.exports = {
 			REBOOT: 'CMD.020503',
 			// event: 2-digit hex for the selected event
 			RECALL_EVENT: 'CMD.030502{event}',
+			// macroHex: 2-digit hex for the selected macro
+			RECALL_MACRO: 'CMD.04058100{macroHex}',
 			// me: which me to transition
 			TRANS_ME_AUTO: 'SET.ME_XPT_ME{me}_BKGD_TRS_AUTO_STAT:1',
 			// me: which me to transition

--- a/protocol_hvs2000.js
+++ b/protocol_hvs2000.js
@@ -6,6 +6,8 @@ module.exports = {
 			//REBOOT: "CMD.020103", // Not supported on HVS2000
 			// event: 2-digit hex for the selected event
 			//RECALL_EVENT: "CMD.030502{event}",
+			// macroInt: which macro to recall
+			RECALL_MACRO: 'SET.MACRO_PLAY:{macroInt}=0',
 			// me: which me to transition
 			TRANS_ME_AUTO: 'SET.M{me}BG_TRANSITION:AUTO',
 			// me: which me to transition


### PR DESCRIPTION
I have tested this on an HVS110 model and it works correctly.

I don't have an HVS2000 to test on, but based on [this slack comment](https://bitfocusio.slack.com/archives/CAV2ACADU/p1654620441117949?thread_ts=1654023341.692679&cid=CAV2ACADU), It should also work there.